### PR TITLE
Add main script with dummy applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local config
+.env
+
+# Local kube config
+.kube

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/helm/test/.helmignore
+++ b/helm/test/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/test/Chart.yaml
+++ b/helm/test/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: test
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/test/templates/NOTES.txt
+++ b/helm/test/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "test.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "test.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "test.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "test.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/test/templates/_helpers.tpl
+++ b/helm/test/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "test.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "test.labels" -}}
+helm.sh/chart: {{ include "test.chart" . }}
+{{ include "test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "test.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "test.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/test/templates/deployment.yaml
+++ b/helm/test/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "test.fullname" . }}
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "test.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "test.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "test.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/test/templates/hpa.yaml
+++ b/helm/test/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "test.fullname" . }}
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "test.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/test/templates/ingress.yaml
+++ b/helm/test/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "test.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/test/templates/service.yaml
+++ b/helm/test/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "test.fullname" . }}
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "test.selectorLabels" . | nindent 4 }}

--- a/helm/test/templates/serviceaccount.yaml
+++ b/helm/test/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "test.serviceAccountName" . }}
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/test/templates/tests/test-connection.yaml
+++ b/helm/test/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "test.fullname" . }}-test-connection"
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/test/values.yaml
+++ b/helm/test/values.yaml
@@ -1,0 +1,107 @@
+# Default values for test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/run.sh
+++ b/run.sh
@@ -125,11 +125,10 @@ deploy_helm() {
     find "${SCRIPT_DIR}/helm" -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' subdir; do 
         release="$(basename "${subdir}")"
         info "Deploying chart ${release} from ${subdir}"
-        if helm status "${release}" > /dev/null; then
+        if helm status "${release}" &> /dev/null; then
             info "${release} already installed, upgrading instead."
             helm upgrade "${release}" "${subdir}"
         else
-            info "Installing helm release ${release} from ${subdir}"
             helm install "${release}" "${subdir}"
         fi
     done

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+#
+# TODO
+#
+
+set -e
+
+### Global read-only constants
+readonly TIME_FORMAT='+%Y-%m-%dT%H:%M:%SZ'
+date -u "${TIME_FORMAT}" > /dev/null
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+readonly SCRIPT_DIR
+
+usage() {
+    # Print usage information about this script to STDOUT.
+    echo
+    echo "Usage: ${BASH_SOURCE[0]} [ACTION]"
+    echo
+    echo "  [ACTION]     Action to perform"
+    echo "    Allowed options:"
+    echo "       - start:  Start k8s cluster"
+    echo "       - build:  Build Docker images"
+    echo "       - deploy: Deploy Helm charts to running cluster"
+    echo "       - delete: Stop cluster and remove any created resources"
+    echo "       - test:   TODO"
+    echo "       - k9s:    Start k9s terminal for running cluster"
+    echo
+    echo "  -q | --quiet         Print less messages from this script"
+    echo "  -h | --help          Display this help message"
+    echo
+}
+
+info() {
+    # Print formatted log message to STDOUT unless `QUIET` is true.
+    if [[ "${QUIET}" != "true" ]]; then
+        echo "[$(date -u ${TIME_FORMAT}) INFO  ${BASH_SOURCE[0]}]: $*"
+    fi
+}
+
+error() {
+    # Print formatted error message to STDERR.
+    echo "[$(date -u ${TIME_FORMAT}) ERROR  ${BASH_SOURCE[0]}]: $*" >&2
+}
+
+configure() {
+    # TODO
+    if [[ -f ".env" ]]; then
+        # shellcheck source=/dev/null
+        source ".env"
+    fi
+
+    export KUBECONFIG="${KUBECONFIG:-${SCRIPT_DIR}/.kube/config-hello}"
+}
+
+verify_minikube() {
+    if ! command -v minikube > /dev/null; then
+        error "minicube not found on path! See https://minikube.sigs.k8s.io/docs/start/ for installation steps."
+        exit 1
+    fi
+}
+
+verify_k9s() {
+    if ! command -v k9s > /dev/null; then
+        error "k9s not found on path! See https://k9scli.io/topics/install/ for installation steps."
+        exit 1
+    fi
+}
+
+verify_docker() {
+    if ! command -v docker > /dev/null; then
+        error "docker not found on path! See https://docs.docker.com/engine/install/ for installation steps."
+        exit 1
+    fi
+}
+
+verify_helm() {
+    if ! command -v helm > /dev/null; then
+        error "helm not found on path! See https://helm.sh/docs/intro/install/ for installation steps."
+        exit 1
+    fi
+}
+
+start_minikube() {
+    # TODO
+    verify_minikube
+    minikube start
+}
+
+delete_minikube() {
+    # TODO
+    verify_minikube
+    minikube delete
+}
+
+start_k9s() {
+    # TODO
+    verify_k9s
+    k9s
+}
+
+build_images() {
+    # TODO
+    verify_docker
+
+    info "Attempting to fetch minikube docker-env"
+    # Hacky way to print error message if failed since minikube doesn't use STDERR
+    if ! minikube docker-env; then
+        exit 1
+    fi
+    DOCKER_CONFIG="$(minikube docker-env)"
+    eval "${DOCKER_CONFIG}"
+
+    find "${SCRIPT_DIR}/docker" -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' subdir; do 
+        image="$(basename "${subdir}")"
+        info "Building ${image}"
+        docker build -t "${image}" "${subdir}" 
+    done
+}
+
+deploy_helm() {
+    # TODO
+    verify_helm
+
+    find "${SCRIPT_DIR}/helm" -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -r -d '' subdir; do 
+        release="$(basename "${subdir}")"
+        info "Deploying chart ${release} from ${subdir}"
+        if helm status "${release}" > /dev/null; then
+            info "${release} already installed, upgrading instead."
+            helm upgrade "${release}" "${subdir}"
+        else
+            info "Installing helm release ${release} from ${subdir}"
+            helm install "${release}" "${subdir}"
+        fi
+    done
+
+}
+
+### Entrypoint ###
+main() {
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -q|--quiet)
+                QUIET=true
+                readonly QUIET
+                shift
+                ;;
+            start|build|deploy|delete|test|k9s)
+                ACTION="$1"
+                readonly ACTION
+                shift
+                ;;
+            *)
+                error "Unexpected parameter ${1}"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "${ACTION}" ]; then
+        error "ACTION must be provided"
+        usage
+        exit 1
+    fi
+
+    configure
+
+    case "${ACTION}" in
+        start)
+            info "Starting minikube with config ${KUBECONFIG}"
+            start_minikube
+            ;;
+        build)
+            info "Building all images in ${SCRIPT_DIR}/docker within minikube VM"
+            build_images
+            ;;
+        deploy)
+            info "Deploying helm charts from ${SCRIPT_DIR}/helm with config ${KUBECONFIG}"
+            deploy_helm
+            ;;
+        test)
+            info "Testing helm charts from ${SCRIPT_DIR}/helm with config ${KUBECONFIG}"
+            test_helm
+            ;;
+        delete)
+            info "Deleting minikube cluster with config ${KUBECONFIG}"
+            delete_minikube
+            ;;
+        k9s)
+            info "Entering k9s terminal with config ${KUBECONFIG}"
+            start_k9s
+            ;;
+        *)
+            error "Action ${ACTION} not implemented"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/run.sh
+++ b/run.sh
@@ -182,10 +182,10 @@ main() {
             info "Deploying helm charts from ${SCRIPT_DIR}/helm with config ${KUBECONFIG}"
             deploy_helm
             ;;
-        test)
-            info "Testing helm charts from ${SCRIPT_DIR}/helm with config ${KUBECONFIG}"
-            test_helm
-            ;;
+        # test)
+        #     info "Testing helm charts from ${SCRIPT_DIR}/helm with config ${KUBECONFIG}"
+        #     test_helm
+        #     ;;
         delete)
             info "Deleting minikube cluster with config ${KUBECONFIG}"
             delete_minikube


### PR DESCRIPTION
### Description
- Create entrypoint script for primary interaction
- Create blank/default projects for Docker and Helm

### Verification
Ran each `./run.sh` option and validated expected behavior:
- `start` - cluster successfully started
- `build` - Docker images from `docker/` built within the minikube VM
- `deploy` - default helm chart was successfully installed in cluster 
- `delete` - cluster and config was deleted. No docker containers were running.